### PR TITLE
 #5 - compile: missing default jsme.tgz; replaced by official tgz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,11 +77,14 @@ RUN apt-get update && \
 USER wims
 WORKDIR /home/wims
 COPY patch.txt /home/wims
-RUN wget https://sourcesup.renater.fr/frs/download.php/file/6667/wims-4.26.tgz && \
-    tar xzf wims-4.26.tgz && \
-    rm wims-4.26.tgz && \
+COPY compile.patch /home/wims
+RUN wget https://sourcesup.renater.fr/frs/download.php/file/6702/wims-4.28.tgz && \
+    tar xzf wims-4.28.tgz && \
+    rm wims-4.28.tgz && \
     patch -p1 < patch.txt && \
+    patch < compile.patch && \
     rm patch.txt && \
+    rm compile.patch && \
     (yes "" | ./compile --mathjax --jmol --modules --geogebra --shtooka)
 
 # Configure WIMS and entry-point

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+current-dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+docker-compose := docker compose -f $(current-dir)docker-compose.yml
+make := /usr/bin/make
+
+.PHONY: all
+all: build-quick-and-restart
+
+.PHONY: build-quick-and-restart
+build-quick-and-restart: build-quick restart
+
+.PHONY: build-quick
+build-quick:
+	$(docker-compose) build
+
+.PHONY: build-full-and-restart
+build-full-and-restart: build-full restart
+
+.PHONY: build-full
+build-full:
+	$(docker-compose) build --no-cache
+
+.PHONY: start
+start:
+	$(docker-compose) up -d
+
+.PHONY: destroy
+destroy:
+	$(docker-compose) down
+
+.PHONY: restart
+restart: destroy start
+
+.PHONY: activate-rsyslog-for-forensyc
+activate-rsyslog-for-forensyc:
+	$(docker-compose) exec wims apt update
+	$(docker-compose) exec wims apt install -y rsyslog
+	$(docker-compose) exec wims /etc/init.d/rsyslog restart
+	$(docker-compose) exec wims /etc/init.d/rsyslog status
+
+# Wildcard target to output target execution duration.
+# How to use this:
+#  1. Have a target named 'do-something:'
+#  2.a. Invoke target named 'make do-something' to invoke it as is.
+#  2.b. Invoke target named 'make do-something-echoed' to invoke it with START and END echoed lines.
+%-echoed:
+	$(eval target := $(subst -echoed,,$@))
+	@echo `date +"%Y-%m-%d %H:%M:%S"`" === START:" $(target)
+	@bash -c "set -m; trap 'exit 0' INT; $(make) --no-print-directory $(target)"
+	@echo `date +"%Y-%m-%d %H:%M:%S"`" === END  :" $(target)

--- a/compile.patch
+++ b/compile.patch
@@ -1,0 +1,11 @@
+--- compile	2022-05-12 15:23:50.000000000 +0200
++++ compile	2024-11-04 11:22:21.482791703 +0100
+@@ -141,7 +141,7 @@
+   if [ "$jsmol" = 1 ] || [ "$opt" = "--jme" ]; then
+     echo "downloading JSME"
+     cd tmp;
+-    wget 'https://wimstest1.di.u-psud.fr/wims/jsme.tgz' -O jsme.tgz
++    wget 'https://wims1.math.cnrs.fr/wims/jsme.tgz' -O jsme.tgz
+     if [ -f "jsme.tgz" ] ; then
+       tar xzf jsme.tgz
+       rm -f jsme.tgz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  wims:
+    image: amatogianluca/wims:4.28
+    build:
+      context: .
+    security_opt:
+      - seccomp:unconfined
+    hostname: wims-4-28
+    container_name: wims-4-28
+    restart: always
+    ports:
+      - 10000:80


### PR DESCRIPTION
closes #5 

This is the PR.

I provide the file with the patch and other utilities to make easier to locally test image generation and running.

I also provide the upgrade to wims 4.28 currently available.